### PR TITLE
Added files to allow this proof to be ran on the external CI

### DIFF
--- a/.github/workflows/amd64-linux.yml
+++ b/.github/workflows/amd64-linux.yml
@@ -112,4 +112,20 @@ jobs:
       - name: return error
         run: make -C proof/ CI=1 err
 
+  # proof (using runtest)
+  proof-runtest:
+    runs-on: [self-hosted, linux, X64, amd64-main]
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: preprocess
+        run: make -j$JOBS -C src/ CI=1 preprocess-inplace
+
+      - name: run proof
+        run: make -j$JOBS -C proof/ all-runtest
+      - name: print report
+        run: make -C proof/ CI=1 reporter
+      - name: return error
+        run: make -C proof/ CI=1 err
+
 

--- a/proof/Makefile
+++ b/proof/Makefile
@@ -127,6 +127,12 @@ all-no-report:
 	$(MAKE) check-extracted
 	$(MAKE) check-all
 
+all-runtest: CI=1
+all-runtest:
+	$(MAKE) distclean
+	$(MAKE) -C $(SRC) extract-to-easycrypt
+	(cd $(PROOF)/crypto_scalarmult/curve25519 && $(EASYCRYPT) runtest tests.config curve25519)
+
 # -----------------------------------------------------------------------------
 # clean rules
 

--- a/proof/crypto_scalarmult/curve25519/easycrypt.project
+++ b/proof/crypto_scalarmult/curve25519/easycrypt.project
@@ -1,0 +1,3 @@
+[general]
+idirs = ../../arrays/
+rdirs = amd64

--- a/proof/crypto_scalarmult/curve25519/tests.config
+++ b/proof/crypto_scalarmult/curve25519/tests.config
@@ -1,0 +1,2 @@
+[test-curve25519]
+okdirs  = !amd64


### PR DESCRIPTION
Hi all, I added two files to allow this proof to be added to the Easycrypt external CI.

As this repository will eventually have the ed25519 proof, I added both the `tests.config` and `easycrypt.project` to the `proof/crypto_scalarmult/curve25519/` folder. 

The external CI would effectively run in the working directory `proof/crypto_scalarmult/curve25519/`:

```sh
easycrypt runtest tests.config curve25519 
```

To avoid multiple `tests.config` files when we have the ed25519 proof, I could move said file to the `proof/` directory so that the external CI would run `easycrypt runtest ../../tests.config curve25519`.

In my Easycrypt fork, I added the following to the `external.json` file and made a PR https://github.com/EasyCrypt/easycrypt/pull/642:

```json
 { "name"       : "curve25519"
  , "repository" : "https://github.com/formosa-crypto/formosa-25519"
  , "branch"     : "main"
  , "subdir"     : "proof/crypto_scalarmult/curve25519"
  , "config"     : "tests.config"
  , "scenario"   : "curve25519"
  , "options"    : ""
  }
  ```
  
  Please provide feedback and if everything looks good, I can go ahead and make 